### PR TITLE
Using schema property title instead of key name

### DIFF
--- a/pwa/src/templates/wooItemDetailTemplate/WOOItemDetailTemplate.tsx
+++ b/pwa/src/templates/wooItemDetailTemplate/WOOItemDetailTemplate.tsx
@@ -83,7 +83,7 @@ export const WOOItemDetailTemplate: React.FC<WOOItemDetailTemplateProps> = ({ wo
       case "Organisatieonderdeel":
         return t("Organizational unit");
       default:
-        return t(upperFirstName);
+        return t(getItems.data["@self"].schema.properties[name]?.title ?? upperFirstName);
     }
   };
 


### PR DESCRIPTION
Unless there is no title, then we do it as usual
