### PR TITLE
Ci/ghcr pipeline

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -32,10 +32,7 @@ name: Container image (ghcr)
 
 on:
   push:
-    branches:
-      - main
-      - development
-      - ci/ghcr-pipeline   # TIJDELIJK: pilot-trigger — verwijderen in de PR naar development
+    branches: [main, development]
     tags: ["v*.*.*"]
   pull_request:
     branches: [main, development]

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,112 @@
+# .github/workflows/container.yml — woo-website-v2 → ghcr.io
+#
+# Tag-schema (besluit 2026-07-15, industriestandaard, git-SHA als anker):
+#   sha-<volledige commit-sha>  immutable anker, ELKE build (format=long is
+#     bewust: de metadata-action-default is een 7-teken short-sha en dat gaf
+#     een mismatch met pin-referenties). De sha-tag is letterlijk het
+#     git-anker; deployments pinnen hierop (of op digest), NOOIT op een
+#     beweegbare pointer.
+#   :development / :main        beweegbare pointers, volgen hun branch
+#     (bewust GEEN :latest — er bestonden twee verschillende "latest" op twee
+#     registries). Alleen voor dev-gemak met pullPolicy Always.
+#   :vX.Y.Z                     semver bij een git-tag vX.Y.Z (promotie-anker).
+# Promotie = sha bumpen in Git. Geen datum-tags, geen omgeving-in-tag.
+#
+# Tooling: docker/metadata-action genereert alle tags declaratief;
+# docker/build-push-action bouwt (BuildKit) en pusht. Geen custom tag-logica.
+# Push-auth via het ingebouwde GITHUB_TOKEN (permissions: packages: write) —
+# geen PAT, geen registry-secret.
+#
+# provenance: false is een BEWUSTE BEVEILIGINGSKEUZE VOOR DE PILOT, geen
+# stille default: SLSA-provenance staat hiermee UIT, terwijl die voor
+# Common Ground/overheid juist waarde heeft. Geregistreerd als
+# heroverwegingspunt (besluitregister 2026-07-15): na de pilot bewust
+# aanzetten. De metadata-action-labels zetten wél
+# org.opencontainers.image.revision (de git-SHA) in elk image, zodat
+# "van welke commit komt dit image" altijd beantwoordbaar is.
+#
+# Actions gepind op commit-SHA (supply-chain-beleid; geresolved via de
+# GitHub-API op 2026-07-15, tag in de comment).
+
+name: Container image (ghcr)
+
+on:
+  push:
+    branches:
+      - main
+      - development
+      - ci/ghcr-pipeline   # TIJDELIJK: pilot-trigger — verwijderen in de PR naar development
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main, development]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # GATSBY_*-defaults uit .env als build-args, zelfde gedrag als de
+      # Codeberg-kaniko-flow (regel-gebaseerd; .env is niet source-baar door
+      # unquoted spaties). Alleen omringende quotes strippen. Tenant-config
+      # blijft runtime (runtime.json-overlay) — dit zijn alleen bake-defaults.
+      - name: GATSBY_* build-args uit .env
+        id: buildargs
+        run: |
+          {
+            echo 'args<<BUILDARGS_EOF'
+            grep -E '^GATSBY_[A-Za-z0-9_]+=' .env \
+              | sed -e 's/^\([^=]*\)="\(.*\)"$/\1=\2/' \
+                    -e "s/^\([^=]*\)='\(.*\)'$/\1=\2/"
+            echo 'BUILDARGS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login ghcr
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Alle tag-logica zit HIER, declaratief. metadata-action lowercased de
+      # image-naam zelf (ConductionNL → conductionnl).
+      - name: Docker metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/woo-website-v2
+          tags: |
+            type=sha,format=long
+            type=ref,event=branch
+            type=semver,pattern=v{{version}}
+
+      # PR's bouwen wel maar pushen niet (push: false is de zichtbare
+      # garantie — zelfde principe als de build/push-splitsing in de
+      # Codeberg-workflow).
+      - name: Build (en push bij branch/tag-pushes)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: pwa
+          file: pwa/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GATSBY_CPU_COUNT=2
+            ${{ steps.buildargs.outputs.args }}


### PR DESCRIPTION
Titel: ci: container-build naar ghcr.io met sha-anker-tagschema

 Nieuwe CI-pipeline op GitHub Actions, onderdeel van de registry-migratie na het tag-incident van 15-07. Tag-schema (industriestandaard, git-SHA als anker): sha-<volledige sha> per build (immutable, nooit ge-GC'd — dé fix voor de verweesde-digest-incidenten), :development/:main als beweegbare pointers, vX.Y.Z bij releases. Tooling: docker/metadata-action +
 build-push-action, allA; push via GITHUB_TOKEN
 (geen PAT). PR's bouwee: false is een
 gedocumenteerde pilot-r Common Ground).

 Bewezen op de pilot-brtag + pointer in ghcr met digest-match, org.openommit, anoniem pulbaar.
Na merge: de eerste deerge-commit> — hetpin-target voor de tenegwerp-tags + deze branch opruimen; Forgejo-worklgt als aparte stap.