### PR TITLE
ci: align workflows with fleet standard (ConductionNL/.github)

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,11 @@
+name: Branch Protection
+
+on:
+  pull_request:
+    branches: [main, beta]
+
+permissions: {}
+
+jobs:
+  branch-protection:
+    uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,11 +12,15 @@ concurrency:
   group: quality-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
-# Least privilege for the called quality pipeline: the Quality Report job
-# posts a sticky PR comment (issues/pull-requests write); everything else
-# only reads the checkout.
+# Permission CEILING for the called quality pipeline. GitHub statically
+# validates the called workflow's declared job permissions against this
+# grant — even for jobs that are disabled — so it must cover the maximum
+# any nested job declares: journeydoc-capture (contents+actions write),
+# update-baseline / features-extract (contents write), and the Quality
+# Report PR comment (issues / pull-requests write).
 permissions:
-  contents: read
+  contents: write
+  actions: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,44 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [main, beta, development, feature/**, bugfix/**, hotfix/**]
+  pull_request:
+    types: [opened, reopened]
+    branches: [main, beta, development]
+  workflow_dispatch:
+
+concurrency:
+  group: quality-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+# Least privilege for the called quality pipeline: the Quality Report job
+# posts a sticky PR comment (issues/pull-requests write); everything else
+# only reads the checkout.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  quality:
+    if: github.event_name != 'push' || github.event.created != true
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
+    with:
+      app-name: woo-website-template-apiv2
+      # Gatsby site living entirely in pwa/ — no root package.json and no
+      # composer.json anywhere.
+      enable-php: false
+      frontend-path: pwa
+      enable-frontend: true
+      # eslint/stylelint were never enforced in this repo; the lint script
+      # (eslint + prettier) and typecheck can be enabled once the codebase
+      # passes them. stylelint has no npm script here at all.
+      enable-eslint: false
+      enable-stylelint: false
+      # The Gatsby production build is this repo's real quality gate — the
+      # only thing the legacy pull-request-build-check enforced.
+      frontend-checks: '["build"]'
+      # No openspec/specs and no docs/features.json — the features check
+      # would fail on every PR comparing "" against "[]".
+      enable-features-extract: false


### PR DESCRIPTION
## What

Aligns this repo's CI with the fleet standard shared workflows in `ConductionNL/.github`
(reference: [openregister](https://github.com/ConductionNL/openregister/tree/main/.github/workflows)).

Depending on the branch this fixes/adds:
- `branch-protection.yml` with caller job id `branch-protection` → check reports as
  `branch-protection / check-branch` (required by the org ruleset)
- `code-quality.yml` as a thin wrapper around the shared `quality.yml` → checks report as
  `quality / …`
- broken `Conduction/.github` references (org doesn't exist; correct org is `ConductionNL`)
- removal of superseded legacy workflows

## Why

Required checks match on exact names. Wrong job ids, the org typo, and legacy workflow
names left PRs hanging on *"Expected — waiting for status to be reported"*.

The corrected checks run **on this PR itself** (PR workflows run from the source branch),
so a green merge box here is the proof it works.

## After merge

Update the branch protection of `main`/`beta` to require the new `quality / …` contexts
and remove any stale `PHP Quality` / `Frontend Quality` entries.