### PR TITLE
docs: document dependency license policy and merge-commit versioning rules

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -273,9 +273,9 @@ jobs:
                      "(no \`fix:\`/\`feat:\` changes since the last release)"
               fi
               echo ""
-              echo "_Preview is computed from the commits in this PR (semantic-release" \
-                   "dry-run); on squash-merge the PR title makes the final call — see" \
-                   "docs/CONTRIBUTING.md._"
+              echo "_Preview via semantic-release dry-run over the commits in this PR —" \
+                   "the same commits the release run analyzes after the merge commit" \
+                   "lands, so this is exact (barring races with other merges)._"
               echo ""
               echo "Tags this build would publish (PR check, or the build/smoke stage failed):"
             fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -4,15 +4,17 @@
 # feat: -> minor, feat!/BREAKING CHANGE -> major), so a wrong message means a
 # wrong version — silently. Two checks:
 #
-#   title    PR title must be a Conventional Commit. Feature/hotfix PRs are
-#            squash-merged, so the TITLE becomes the commit that
-#            semantic-release reads. Skipped for the promotion PRs
-#            (development→beta, beta→main) — those are merge commits whose
-#            title never enters history.
 #   commits  every commit in the PR must be a Conventional Commit
 #            (commitlint; merge commits are ignored by its default rules).
-#            This is the CI backstop for the local .husky/commit-msg hook,
-#            which can be bypassed with --no-verify.
+#            THIS IS THE VERSION GATE: all PRs are merged with merge
+#            commits, so the individual branch commits are what
+#            semantic-release reads — every fix:/feat: commit bumps the
+#            version and lands in the changelog. CI backstop for the local
+#            .husky/commit-msg hook, which can be bypassed with --no-verify.
+#   title    PR title must be a Conventional Commit — hygiene for a readable
+#            PR overview (the title itself never enters history). Skipped
+#            for the promotion PRs (development→beta, beta→main) and
+#            backmerge/* PRs, whose titles are descriptive.
 #
 # The `github.server_url` guard exists because Forgejo/Codeberg also executes
 # files under .github/workflows; these jobs are GitHub-only and must be a
@@ -42,7 +44,8 @@ jobs:
     if: >-
       github.server_url == 'https://github.com' &&
       github.head_ref != 'development' &&
-      github.head_ref != 'beta'
+      github.head_ref != 'beta' &&
+      !startsWith(github.head_ref, 'backmerge/')
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,15 @@ When writing or suggesting a pull request:
   `beta → main`, and the automated `backmerge/*` PRs; their titles may be
   descriptive ("Release v1.2.0").
 - **Description: only the commits being merged.** Describe what this PR
-  changes and why — nothing else. No test plans, no review notes, no side
-  findings, no follow-ups for other repos, no version-effect explanations.
-  Anything discovered *while* doing the work but not *part of* the change
-  goes to the requester in chat or into a separate issue.
+  changes and why — nothing else. No test plans, no side findings, no
+  follow-ups for other repos, no version-effect explanations. Anything
+  discovered *while* doing the work but not *part of* the change goes to the
+  requester in chat or into a separate issue.
+- **Review notes: only to preempt a predictable reviewer question about THIS
+  change.** Example that qualifies: "upgrading the flagged packages doesn't
+  fix their licenses — latest versions use the same license form" (answers
+  the inevitable "why not just update?"). Not qualified: inventories of
+  things found along the way, or suggestions for other repos.
 
 ## Branch flow & merge methods
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,28 +28,30 @@ Rules:
   propose the corrected form.
 - Never bypass the `.husky/commit-msg` hook (`--no-verify`) — CI re-checks
   every PR anyway (`.github/workflows/pr-lint.yml`).
+- **Every branch commit enters history and counts** (all PRs are merged with
+  merge commits — no squash). Use `fix:`/`feat:` only on commits that really
+  contain that kind of change; intermediate and cleanup work is
+  `chore:`/`refactor:`/`docs:`. Every `fix:`/`feat:` commit also becomes a
+  line in the release changelog. Mark breaking changes in the commit itself
+  (`feat!:` or a `BREAKING CHANGE:` footer).
 
-## PR titles & descriptions (MANDATORY for titles)
+## PR titles & descriptions
 
 When writing or suggesting a pull request:
 
-- **Title = a Conventional Commit, and it decides the version.** Feature/hotfix
-  PRs are squash-merged, so the PR title becomes the commit that
-  semantic-release reads. Choose the type by what the change does to the
-  shipped Docker image: `fix:` → patch, `feat:` → minor, workflow/docs-only
-  work → `ci:`/`docs:` (no release). Enforced by `pr-lint.yml` — a wrong
-  title blocks the merge.
-- **Breaking changes: mark them in the title** with `!` (`feat!: …` or
-  `fix!: …`). Do not rely on a `BREAKING CHANGE:` footer hidden in the
-  description — the title is the reliable part of the squash commit.
-- **Exempt PRs** (merge-committed, title never enters history — pr-lint skips
-  the title check for these): `development → beta`, `beta → main`, and the
-  automated `backmerge/*` PRs. Their titles may be descriptive
-  ("Release v1.2.0"); never squash-merge them.
-- **Description is free-form** (no lint) and has no version effect. Include:
-  what changed and why, how it was tested, and any manual steps. For PRs into
-  `development`, note the expected version effect of the title (e.g. "`fix:`
-  → will release a patch prerelease on merge").
+- **The version is decided by the branch commits, not the title** (merge-commit
+  merging: the title never becomes a commit). semantic-release takes the
+  highest bump across the newly merged commits — one release per merge, not
+  one per commit.
+- **Title: still a Conventional Commit** — enforced by `pr-lint.yml`, for a
+  readable PR overview. Exempt (title check skipped): `development → beta`,
+  `beta → main`, and the automated `backmerge/*` PRs; their titles may be
+  descriptive ("Release v1.2.0").
+- **Description: only the commits being merged.** Describe what this PR
+  changes and why — nothing else. No test plans, no review notes, no side
+  findings, no follow-ups for other repos, no version-effect explanations.
+  Anything discovered *while* doing the work but not *part of* the change
+  goes to the requester in chat or into a separate issue.
 
 ## Branch flow & merge methods
 
@@ -58,17 +60,16 @@ When writing or suggesting a pull request:
 directly to `main`). `beta` is a pass-through required by org branch
 protections — it gets no tags, releases, or images.
 
-| PR | Merge method |
-|---|---|
-| feature/fix branch → `development` | **Squash** |
-| `hotfix/*` → `main` | **Squash** |
-| `development` → `beta`, `beta` → `main` | **Merge commit — never squash, never rebase** |
-| back-merge `main` → `development` (after each stable release) | **Merge commit — never squash** |
+**Every PR is merged with a MERGE COMMIT** — feature branches, hotfixes,
+promotions and back-merges alike. Never squash, never rebase-merge:
 
-Squashing a promotion or back-merge PR collapses the release history into one
-commit: the version bump would then be decided by that single title, and
-development would lose the release tags it needs to compute correct prerelease
-versions.
+- Squashing a promotion or back-merge collapses the release history into one
+  commit — the version would be decided by a single title, and development
+  would lose the release tags it needs for correct prerelease versions.
+- Rebase-merging rewrites commit SHAs, breaking the `sha-<sha>` image-tag
+  anchors.
+- Merge commits themselves ("Merge pull request …") are harmless: commitlint
+  and semantic-release both ignore them.
 
 ## Versioning (context)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -59,28 +59,34 @@ Let op:
 - Een lokale git-hook (`.husky/commit-msg`, via husky/commitlint) weigert
   afwijkende berichten direct bij het committen; CI controleert daarnaast elke
   PR (titel én alle commits), dus omzeilen met `--no-verify` heeft geen zin.
-- PR-titels volgen dezelfde conventie: feature/hotfix-PR's worden ge-squash-merged,
-  waardoor de PR-titel de commit wordt die de versie bepaalt. Markeer een
-  breaking change daarom in de titel zelf met `!` (bijv. `feat!: …`), niet
-  alleen in een footer.
-- Uitzondering: de promotie-PR's (`development → beta`, `beta → main`) en de
-  automatische `backmerge/*`-PR's worden met een merge commit samengevoegd —
-  hun titel komt nooit in de historie en hoeft dus geen Conventional Commit te
-  zijn (de titel-check slaat ze over).
+- Alle PR's worden met een **merge commit** samengevoegd. Daardoor komt elke
+  individuele commit van je branch in de historie terecht en telt **elke
+  commit mee voor de versie** — niet de PR-titel. Gebruik `fix:`/`feat:` dus
+  alleen voor commits die écht een gebruikersgerichte wijziging bevatten;
+  tussenstappen en opruimwerk zijn `chore:`/`refactor:`/`docs:`. Elke
+  `fix:`/`feat:`-commit wordt ook een regel in de changelog.
+- Markeer een breaking change in de commit zelf: `feat!: …` (of een
+  `BREAKING CHANGE:`-footer).
+- PR-titels volgen dezelfde conventie (CI controleert dit) — voor een leesbaar
+  PR-overzicht; de versie wordt bepaald door de commits. Uitzondering: de
+  promotie-PR's (`development → beta`, `beta → main`) en de automatische
+  `backmerge/*`-PR's — hun titel hoeft geen Conventional Commit te zijn (de
+  titel-check slaat ze over).
 
-### Merge-methodes per branch-paar
+### Merge-methode
 
-| PR | Merge-methode |
-|---|---|
-| feature/fix-branch → `development` | **Squash** |
-| `hotfix/*` → `main` | **Squash** |
-| `development` → `beta` en `beta` → `main` | **Merge commit — nooit squashen of rebasen** |
-| back-merge `main` → `development` (na elke stabiele release) | **Merge commit — nooit squashen** |
+**Alle PR's worden met een merge commit samengevoegd** — feature-branches,
+hotfixes, promoties (`development → beta → main`) en back-merges. Squash en
+rebase worden niet gebruikt (bij voorkeur uitgezet in de repo-instellingen):
 
-Squashen van een promotie- of back-merge-PR klapt de release-historie samen tot
-één commit: de versie-bump zou dan door die ene titel bepaald worden en
-`development` verliest de release-tags die het nodig heeft om correcte
-prerelease-versies te berekenen.
+- Squashen van een promotie- of back-merge-PR klapt de release-historie samen
+  tot één commit — de versie zou dan door één titel bepaald worden en
+  `development` verliest de release-tags die het nodig heeft voor correcte
+  prerelease-versies.
+- Rebase-mergen herschrijft commit-SHA's, waardoor de `sha-<sha>`-image-tags
+  niet meer terugwijzen naar de gebouwde commits.
+- Merge commits zelf ("Merge pull request …") zijn onschadelijk: commitlint en
+  semantic-release negeren ze allebei.
 
 ## Licenties van dependencies
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,3 +81,23 @@ Squashen van een promotie- of back-merge-PR klapt de release-historie samen tot
 één commit: de versie-bump zou dan door die ene titel bepaald worden en
 `development` verliest de release-tags die het nodig heeft om correcte
 prerelease-versies te berekenen.
+
+## Licenties van dependencies
+
+CI controleert alle npm-dependencies tegen een lijst goedgekeurde licenties
+(zie ook de sectie *Licensing* in de README). Voor bijdragers is dit relevant:
+
+- Voegt een nieuwe dependency zonder geldige SPDX-licentie een fout toe aan de
+  "License (npm)"-check? Neem de package dan alleen op als daar een goede reden
+  voor is, en voeg een entry toe aan
+  [`.license-overrides.json`](../.license-overrides.json) met onderbouwing,
+  je GitHub-handle en datum (zie de bestaande entries voor het formaat).
+- `pwa/package.json` bevat bewust **`"private": true`**: dit is een website,
+  geen npm-package. De vlag maakt `npm publish` onmogelijk — ook per ongeluk,
+  bijvoorbeeld door CI-tooling (semantic-release's npm-plugin slaat publiceren
+  over dankzij deze vlag). **Niet verwijderen.**
+- Daardoor rapporteert license-checker onze eigen package altijd als
+  `UNLICENSED`: de tool negeert het licentieveld van private packages. Het
+  licentieveld (`EUPL-1.2`) is correcte metadata voor mensen en andere tooling,
+  en de eigen package heeft daarnaast een entry in `.license-overrides.json`
+  voor de check. Beide zijn nodig; geen van beide is overbodig.


### PR DESCRIPTION
## Dependency license policy (CONTRIBUTING)

New `Licenties van dependencies` section for contributors: how to add a justified entry to `.license-overrides.json` when a new dependency lacks a valid SPDX license, why `pwa/package.json` deliberately has `private: true` and must keep it (blocks any `npm publish`, including by CI tooling), and why our own package needs both the `EUPL-1.2` license field and an override entry (license-checker ignores the license field of private packages).

## Versioning rules reworked for merge-commit-only merging

All PRs are merged with merge commits (no squash, no rebase), so the individual branch commits — not the PR title — determine the version and the changelog. Updated accordingly:

- **CONTRIBUTING / CLAUDE.md**: every `fix:`/`feat:` commit bumps the version and becomes a changelog line, so those types belong only on commits that really contain such a change; intermediate work is `chore:`/`refactor:`. Breaking changes are marked in the commit itself. Merge-method table replaced by the single rule with the reasons squash/rebase stay forbidden.
- **pr-lint.yml**: the commits check is documented as the version gate; the title check remains as hygiene and now also skips the automated `backmerge/*` PRs.
- **dockerimage.yml**: the PR version-preview note now states the preview is exact — it analyzes the same commits the release run sees after the merge.

## PR-authoring conventions (CLAUDE.md)

Deliberately bundled here: the AI-facing rules for PR descriptions. A description covers only the commits being merged; review notes are allowed solely when they preempt a predictable reviewer question about the change at hand. The wording was tightened in this PR after review feedback — the earlier absolute "no review notes" contradicted the agreed practice.

## Review notes

- Repo-wide sweep for remaining `squash` references: the seven matches left (CLAUDE.md, CONTRIBUTING, release.yml) are all intentional "never squash" prohibitions — no stale descriptions of the old squash-based flow remain in README, workflows, docs, or templates.
