### PR TITLE
feat: add openwoo theme via conduction theme 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ volledige werkwijze en de merge-regels per branch.
 
 Docker-images staan op `ghcr.io/conductionnl/woo-website-v2`:
 
-| Image-tag | Betekenis |
-|---|---|
+| Image-tag                    | Betekenis                                                                       |
+| ---------------------------- | ------------------------------------------------------------------------------- |
 | `sha-<volledige commit-sha>` | Onveranderlijk anker per commit — deployments pinnen hierop of op een versietag |
-| `vX.Y.Z` | Stabiele release (main) |
-| `vX.Y.Z-development.N` | Ontwikkel-iteratie N richting versie X.Y.Z |
-| `main` / `development` | **Bewegende** branch-pointers — alleen voor lokaal gemak |
+| `vX.Y.Z`                     | Stabiele release (main)                                                         |
+| `vX.Y.Z-development.N`       | Ontwikkel-iteratie N richting versie X.Y.Z                                      |
+| `main` / `development`       | **Bewegende** branch-pointers — alleen voor lokaal gemak                        |
 
 Pin een omgeving (ook test/acceptatie) altijd op een **volledige versietag of
 sha-tag**, nooit op `development` of `main`: bewegende pointers veranderen bij
@@ -60,12 +60,14 @@ licentierapport van elke build is als artifact te vinden bij de
 "License (npm)"-check in GitHub Actions.
 
 ### Snel starten (Node, zonder Docker)
+
 1. Ga naar de PWA-map: `cd pwa`
 2. Installeer dependencies: `npm ci` (of `npm install`)
 3. Start lokaal: `npm run dev`
 4. Bezoek: `http://localhost:8000`
 
 Let op: de `localhost.json` zet `GATSBY_API_BASE_URL` op `/api` (handig in Docker met NGINX-proxy). In pure Node dev is er geen proxy, dus kies één van deze opties:
+
 - Zet env-mode aan met acceptatie-API: maak `pwa/static/.env.development` en zet `GATSBY_DEV_ENVIRONMENT=true` (zie voorbeeld hieronder)
 - Of wijzig `pwa/static/configFiles/other/localhost/localhost.json` zodat `GATSBY_API_BASE_URL` een absolute URL is
 
@@ -79,6 +81,7 @@ GATSBY_NL_DESIGN_THEME_CLASSNAME=conduction-theme
 ```
 
 ### Snel starten (Docker Compose)
+
 1. Maak in de repo-root een `.env` met minimaal:
 
 ```
@@ -102,15 +105,18 @@ APP_BUILD=dev
 3. Bezoek: `http://localhost:8000`
 
 Opmerking:
+
 - Compose geeft de Gatsby-variabelen mee als build-args; je hebt dan geen `pwa/static/.env.production` nodig.
 - De NGINX-proxy voor `/api` staat in `pwa/docker/default.conf`. De frontend gebruikt óf `API_BASE_URL` uit sessionStorage (gezet via Gatsby env/JSON-config) óf valt terug op `/api`.
 
 ### Waar komen variabelen vandaan?
+
 - Node dev: `pwa/static/.env.development` (optioneel). Als `GATSBY_ENV_VARS_SET` niet "true" is, gebruikt de app JSON-config uit `pwa/static/configFiles/`.
 - Productie build: `pwa/static/.env.production` of build-args tijdens Docker build (via Compose `.env` in de repo-root).
 - Docker Compose: `.env` in de repo-root wordt automatisch ingelezen door Compose en levert de build-args in `docker-compose.yml`.
 
 ### Minimale variabelen (alleen als je env-mode wil gebruiken)
+
 - `GATSBY_ENV_VARS_SET` = `true` om env-mode te forceren (anders JSON-config)
 - `GATSBY_API_BASE_URL` = jouw backend API-base URL
 - `GATSBY_NL_DESIGN_THEME_CLASSNAME` = CSS theme class (bijv. `conduction-theme`)

--- a/pwa/package-lock.json
+++ b/pwa/package-lock.json
@@ -8,11 +8,12 @@
       "name": "woo-website-template-apiv2",
       "version": "1.0.0",
       "hasInstallScript": true,
+      "license": "EUPL-1.2",
       "dependencies": {
         "@amsterdam/design-system-css": "^3.1.0",
         "@amsterdam/design-system-react": "^3.1.0",
         "@conduction/components": "2.2.59",
-        "@conduction/theme": "1.1.72",
+        "@conduction/theme": "2.1.0",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "6.6.0",
@@ -2822,14 +2823,14 @@
       }
     },
     "node_modules/@conduction/theme": {
-      "version": "1.1.72",
-      "resolved": "https://registry.npmjs.org/@conduction/theme/-/theme-1.1.72.tgz",
-      "integrity": "sha512-DHAQOMljxtet5GIaYa9/iubREXBaaVoVGGLSAzMf6ASJlds+F1r9/udToUmuVGRiC/hIiOO4u3L68t84JstvPA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@conduction/theme/-/theme-2.1.0.tgz",
+      "integrity": "sha512-v6UHZfcgScAWj0n/TrVdPNKLMPAqZNGC5eTFulS+eiE2R2e1xvKbhJOs/n345FOrA2j3HmXRF0G/Nevo9nHdEQ==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@nl-design-system-unstable/rotterdam-design-tokens": "^1.0.0-alpha.100",
-        "npm-run-all": "^4.1.5",
+        "npm-run-all2": "^8.0.4",
         "sass": "^1.70.0",
         "style-dictionary": "^3.9.2"
       }
@@ -16710,6 +16711,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -17309,6 +17311,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -17324,6 +17327,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "error-ex": "^1.3.1",
@@ -18245,6 +18249,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/no-case": {
@@ -18368,6 +18373,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -18380,12 +18386,14 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/normalize-package-data/node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -18407,6 +18415,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -18433,10 +18442,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+      "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
       "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -18462,6 +18481,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -18474,6 +18494,7 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -18484,6 +18505,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -18498,6 +18520,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -18507,12 +18530,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/npm-run-all/node_modules/cross-spawn": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
       "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -18529,6 +18554,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -18538,6 +18564,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18547,6 +18574,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -18559,6 +18587,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -18568,6 +18597,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
       "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "pidtree": "bin/pidtree.js"
@@ -18580,6 +18610,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -18589,6 +18620,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -18601,6 +18633,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18610,6 +18643,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -18622,12 +18656,75 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/npm-run-all2": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-8.0.4.tgz",
+      "integrity": "sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "cross-spawn": "^7.0.6",
+        "memorystream": "^0.3.1",
+        "picomatch": "^4.0.2",
+        "pidtree": "^0.6.0",
+        "read-package-json-fast": "^4.0.0",
+        "shell-quote": "^1.7.3",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "npm-run-all2": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": "^20.5.0 || >=22.0.0",
+        "npm": ">= 10"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -19488,7 +19585,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
       "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "pidtree": "bin/pidtree.js"
@@ -19501,6 +19597,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -20997,10 +21094,33 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/read-package-json-fast": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-4.0.0.tgz",
+      "integrity": "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==",
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
+      "integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "load-json-file": "^4.0.0",
@@ -21015,6 +21135,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^3.0.0"
@@ -22455,6 +22576,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -22465,12 +22587,14 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -22481,6 +22605,7 @@
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/split-on-first": {
@@ -22732,6 +22857,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
       "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -24113,6 +24239,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",

--- a/pwa/package.json
+++ b/pwa/package.json
@@ -52,7 +52,7 @@
     "@amsterdam/design-system-css": "^3.1.0",
     "@amsterdam/design-system-react": "^3.1.0",
     "@conduction/components": "2.2.59",
-    "@conduction/theme": "1.1.72",
+    "@conduction/theme": "2.1.0",
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "6.6.0",

--- a/pwa/src/styling/index.css
+++ b/pwa/src/styling/index.css
@@ -6,42 +6,47 @@
 
 /* Design Tokens maintained by Conduction */
 @import "../../node_modules/@conduction/theme/conduction-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/leiden-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/xxllnc-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/tubbergen-design-tokens/dist/index.css";
+/* Municipalities */
+@import "../../node_modules/@conduction/theme/municipalities/almere-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/baarn-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/beek-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/buren-design-tokens/dist/index.css";
 @import "../../node_modules/@conduction/theme/municipalities/dinkelland-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/ede-design-tokens/dist/index.css";
 @import "../../node_modules/@conduction/theme/municipalities/epe-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/noordwijk-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/noaberkracht-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/rotterdam-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/open-webconcept-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/dimpact-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/commonground-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/opencatalogi-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/zutphen-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/sloterburg-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/gouda-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/zuiddrecht-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/roosendaal-design-tokens/dist/index.css";
 @import "../../node_modules/@conduction/theme/municipalities/gooise-meren-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/moerdijk-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/gouda-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/helmond-design-tokens/dist/index.css";
 @import "../../node_modules/@conduction/theme/municipalities/hof-van-twente-design-tokens/dist/index.css";
 @import "../../node_modules/@conduction/theme/municipalities/lansingerland-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/bct-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/ede-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/oude-ijsselstreek-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/helmond-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/beek-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/baarn-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/stichtse-vecht-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/soest-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/buren-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/almere-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/vaals-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/noorderzijlvest-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/wassenaar-design-tokens/dist/index.css";
-@import "../../node_modules/@conduction/theme/municipalities/voorschoten-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/leiden-design-tokens/dist/index.css";
 @import "../../node_modules/@conduction/theme/municipalities/midden-delfland-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/moerdijk-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/noordwijk-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/oude-ijsselstreek-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/roosendaal-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/rotterdam-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/soest-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/stichtse-vecht-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/tubbergen-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/vaals-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/voorschoten-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/wassenaar-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/municipalities/zutphen-design-tokens/dist/index.css";
+/* Partnerships (samenwerkingsverbanden) */
+@import "../../node_modules/@conduction/theme/partnerships/noaberkracht-design-tokens/dist/index.css";
+/* Water authorities (waterschappen) */
+@import "../../node_modules/@conduction/theme/water-authorities/noorderzijlvest-design-tokens/dist/index.css";
+/* Other (non-municipality) themes */
+@import "../../node_modules/@conduction/theme/other/bct-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/commonground-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/dimpact-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/open-webconcept-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/opencatalogi-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/openwoo-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/sloterburg-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/xxllnc-design-tokens/dist/index.css";
+@import "../../node_modules/@conduction/theme/other/zuiddrecht-design-tokens/dist/index.css";
 
 /* Design Tokens maintained by Frameless */
 @import "../../node_modules/@utrecht/design-tokens/dist/theme.css";


### PR DESCRIPTION
## OpenWOO theme

Updates `@conduction/theme` from 1.1.72 to 2.1.0, which ships the openwoo theme. The municipality imports in `pwa/src/styling/index.css` are restructured to the 2.x theme layout, adding the newly available municipality themes (almere, baarn, beek, buren, ede, and more).
